### PR TITLE
景観まちづくり支援ツールで指摘があったポストエフェクトの調整

### DIFF
--- a/PlateauToolkit.Rendering/Editor/Prefabs/HDRP/Rendering Volume Profile.asset
+++ b/PlateauToolkit.Rendering/Editor/Prefabs/HDRP/Rendering Volume Profile.asset
@@ -118,19 +118,19 @@ MonoBehaviour:
     m_Value: 1
   m_StepCount:
     m_OverrideState: 1
-    m_Value: 6
+    m_Value: 16
   m_FullResolution:
     m_OverrideState: 1
-    m_Value: 0
+    m_Value: 1
   m_MaximumRadiusInPixels:
     m_OverrideState: 1
-    m_Value: 40
+    m_Value: 80
   m_BilateralUpsample:
     m_OverrideState: 1
     m_Value: 1
   m_DirectionCount:
     m_OverrideState: 1
-    m_Value: 2
+    m_Value: 4
   m_RayLength:
     m_OverrideState: 1
     m_Value: 20
@@ -176,7 +176,7 @@ MonoBehaviour:
     m_Value: 2
   limitMax:
     m_OverrideState: 1
-    m_Value: 14
+    m_Value: 13.3
   curveMap:
     m_OverrideState: 1
     m_Value:
@@ -309,10 +309,10 @@ MonoBehaviour:
   active: 1
   temperature:
     m_OverrideState: 1
-    m_Value: -6
+    m_Value: -3
   tint:
-    m_OverrideState: 0
-    m_Value: 0
+    m_OverrideState: 1
+    m_Value: -2
 --- !u!114 &-5028308316047275686
 MonoBehaviour:
   m_ObjectHideFlags: 3
@@ -328,7 +328,7 @@ MonoBehaviour:
   active: 1
   quality:
     m_OverrideState: 1
-    m_Value: 1
+    m_Value: 2
   focusMode:
     m_OverrideState: 1
     m_Value: 2
@@ -352,23 +352,26 @@ MonoBehaviour:
     m_Value: 300000
   m_NearSampleCount:
     m_OverrideState: 1
-    m_Value: 4
+    m_Value: 8
   m_NearMaxBlur:
     m_OverrideState: 1
-    m_Value: 3
+    m_Value: 7
   m_FarSampleCount:
     m_OverrideState: 1
-    m_Value: 5
+    m_Value: 14
   m_FarMaxBlur:
     m_OverrideState: 1
-    m_Value: 6
+    m_Value: 13
   m_Resolution:
     m_OverrideState: 1
-    m_Value: 2
+    m_Value: 1
   m_HighQualityFiltering:
     m_OverrideState: 1
-    m_Value: 0
+    m_Value: 1
   m_PhysicallyBased:
+    m_OverrideState: 1
+    m_Value: 0
+  m_LimitManualRangeNearBlur:
     m_OverrideState: 1
     m_Value: 0
 --- !u!114 &-3323152859500968833
@@ -442,6 +445,27 @@ MonoBehaviour:
   accumulationFactor:
     m_OverrideState: 0
     m_Value: 0.75
+  biasFactor:
+    m_OverrideState: 0
+    m_Value: 0.5
+  speedRejectionParam:
+    m_OverrideState: 0
+    m_Value: 0.5
+  speedRejectionScalerFactor:
+    m_OverrideState: 0
+    m_Value: 0.2
+  speedSmoothReject:
+    m_OverrideState: 0
+    m_Value: 0
+  speedSurfaceOnly:
+    m_OverrideState: 0
+    m_Value: 1
+  speedTargetOnly:
+    m_OverrideState: 0
+    m_Value: 1
+  enableWorldSpeedRejection:
+    m_OverrideState: 0
+    m_Value: 0
   m_RayMaxIterations:
     m_OverrideState: 1
     m_Value: 64
@@ -609,6 +633,9 @@ MonoBehaviour:
   mode:
     m_OverrideState: 1
     m_Value: 2
+  useFullACES:
+    m_OverrideState: 0
+    m_Value: 0
   toeStrength:
     m_OverrideState: 0
     m_Value: 0
@@ -633,6 +660,33 @@ MonoBehaviour:
   lutContribution:
     m_OverrideState: 0
     m_Value: 1
+  neutralHDRRangeReductionMode:
+    m_OverrideState: 0
+    m_Value: 2
+  acesPreset:
+    m_OverrideState: 0
+    m_Value: 3
+  fallbackMode:
+    m_OverrideState: 0
+    m_Value: 1
+  hueShiftAmount:
+    m_OverrideState: 0
+    m_Value: 0
+  detectPaperWhite:
+    m_OverrideState: 0
+    m_Value: 0
+  paperWhite:
+    m_OverrideState: 0
+    m_Value: 300
+  detectBrightnessLimits:
+    m_OverrideState: 0
+    m_Value: 1
+  minNits:
+    m_OverrideState: 0
+    m_Value: 0.005
+  maxNits:
+    m_OverrideState: 0
+    m_Value: 1000
 --- !u!114 &2221381968258264123
 MonoBehaviour:
   m_ObjectHideFlags: 3
@@ -657,10 +711,10 @@ MonoBehaviour:
     m_Value: {r: 0.97547174, g: 1, b: 0.9933615, a: 1}
   hueShift:
     m_OverrideState: 1
-    m_Value: -2
+    m_Value: 0
   saturation:
     m_OverrideState: 1
-    m_Value: 0
+    m_Value: 80
 --- !u!114 &5671803632296313252
 MonoBehaviour:
   m_ObjectHideFlags: 3
@@ -674,6 +728,7 @@ MonoBehaviour:
   m_Name: HDShadowSettings
   m_EditorClassIdentifier: 
   active: 1
+  interCascadeBorders: 1
   maxShadowDistance:
     m_OverrideState: 1
     m_Value: 20000
@@ -694,10 +749,10 @@ MonoBehaviour:
     m_Value: 0.3
   cascadeShadowBorder0:
     m_OverrideState: 1
-    m_Value: 0.13333334
+    m_Value: 0.06905067
   cascadeShadowBorder1:
     m_OverrideState: 1
-    m_Value: 0.06666666
+    m_Value: 0.042385235
   cascadeShadowBorder2:
     m_OverrideState: 0
     m_Value: 0


### PR DESCRIPTION
景観まちづくり支援ツールで指摘があったポストエフェクトの調整を行いました。

> 道路から建物の壁面を見た画像が暗い感じがする。明るくできないのか？全体的に明度を上げられないか？歩行者視点でみると暗い印象あり。

ホワイトバランス・色調（彩度）・DOFあたりを変更しています。
調整前
![pre](https://github.com/user-attachments/assets/0504d45e-bef8-480d-a720-5dffda270c2b)
調整後
![aft](https://github.com/user-attachments/assets/7290335b-d2a2-435f-8249-2abfa817d713)
